### PR TITLE
Initialize study during Firefox startup

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1738,5 +1738,6 @@ pref("app.shield.optoutstudies.enabled", true);
 pref("app.shield.optoutstudies.enabled", false);
 #endif
 
-// Savant Shield study preference
+// Savant Shield study preferences
 pref("shield.savant.enabled", false);
+pref("shield.savant.loglevel", "debug");

--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1737,3 +1737,6 @@ pref("app.shield.optoutstudies.enabled", true);
 #else
 pref("app.shield.optoutstudies.enabled", false);
 #endif
+
+// Savant Shield study preference
+pref("shield.savant.enabled", false);

--- a/browser/components/nsBrowserGlue.js
+++ b/browser/components/nsBrowserGlue.js
@@ -134,6 +134,7 @@ XPCOMUtils.defineLazyModuleGetters(this, {
   Sanitizer: "resource:///modules/Sanitizer.jsm",
   SessionStore: "resource:///modules/sessionstore/SessionStore.jsm",
   ShellService: "resource:///modules/ShellService.jsm",
+  ShieldStudySavant: "resource:///modules/ShieldStudySavant.jsm",
   TabCrashHandler: "resource:///modules/ContentCrashHandlers.jsm",
   UIState: "resource://services-sync/UIState.jsm",
   UITour: "resource:///modules/UITour.jsm",
@@ -1019,6 +1020,8 @@ BrowserGlue.prototype = {
 
     // Set the default favicon size for UI views that use the page-icon protocol.
     PlacesUtils.favicons.setDefaultIconURIPreferredSize(16 * aWindow.devicePixelRatio);
+
+    ShieldStudySavant.init();
   },
 
   _sendMediaTelemetry() {

--- a/browser/modules/ShieldStudySavant.jsm
+++ b/browser/modules/ShieldStudySavant.jsm
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+var EXPORTED_SYMBOLS = ["ShieldStudySavant"];
+
+ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+// See LOG_LEVELS in Console.jsm. Examples: "all", "info", "warn", & "error".
+const PREF_LOG_LEVEL = "shield.savant.loglevel";
+
+// Create a new instance of the ConsoleAPI so we can control the maxLogLevel with a pref.
+XPCOMUtils.defineLazyGetter(this, "log", () => {
+  let ConsoleAPI = ChromeUtils.import("resource://gre/modules/Console.jsm", {}).ConsoleAPI;
+  let consoleOptions = {
+    maxLogLevelPref: PREF_LOG_LEVEL,
+    prefix: "ShieldStudySavant",
+  };
+  return new ConsoleAPI(consoleOptions);
+});
+
+class ShieldStudySavantClass {
+  constructor() {
+    this.SHIELD_STUDY_SAVANT_PREF = "shield.savant.enabled";
+  }
+
+  init() {
+    // check the pref in case Normandy flipped it on before we could add the pref listener
+    this.shouldCollect = Services.prefs.getBoolPref(this.SHIELD_STUDY_SAVANT_PREF);
+    if (this.shouldCollect) {
+      this.enableCollection();
+    }
+    Services.prefs.addObserver(this.SHIELD_STUDY_SAVANT_PREF, this);
+  }
+
+  observe(subject, topic, data) {
+    if (topic === "nsPref:changed" && data === this.SHIELD_STUDY_SAVANT_PREF) {
+      // toggle state of the pref
+      this.shouldCollect = !this.shouldCollect;
+      if (this.shouldCollect) {
+        this.enableCollection();
+      } else {
+        // Normandy has flipped off the pref
+        this.endStudy("expired");
+      }
+    }
+  }
+
+  enableCollection() {
+    log.debug("Study has been enabled; turning on data collection.");
+    // TODO: enable data collection
+  }
+
+  endStudy(reason) {
+    this.disableCollection();
+    // TODO: send endStudy ping with reason code
+    this.uninit();
+  }
+
+  disableCollection() {
+    log.debug("Study has been disabled; turning off data collection.");
+    // TODO: disable data collection
+  }
+
+  uninit() {
+    Services.prefs.removeObserver(this.SHIELD_STUDY_SAVANT_PREF, this);
+    Services.prefs.clearUserPref(this.SHIELD_STUDY_SAVANT_PREF);
+    Services.prefs.clearUserPref(PREF_LOG_LEVEL);
+  }
+};
+
+const ShieldStudySavant = new ShieldStudySavantClass();

--- a/browser/modules/ShieldStudySavant.jsm
+++ b/browser/modules/ShieldStudySavant.jsm
@@ -28,6 +28,12 @@ class ShieldStudySavantClass {
   }
 
   init() {
+    // TODO: implement eligibility (#13)
+    const isEligible = true;
+    if (!isEligible) {
+      this.endStudy("ineligible");
+      return;
+    }
     // check the pref in case Normandy flipped it on before we could add the pref listener
     this.shouldCollect = Services.prefs.getBoolPref(this.SHIELD_STUDY_SAVANT_PREF);
     if (this.shouldCollect) {

--- a/browser/modules/moz.build
+++ b/browser/modules/moz.build
@@ -154,6 +154,7 @@ EXTRA_JS_MODULES += [
     'RemotePrompt.jsm',
     'Sanitizer.jsm',
     'SchedulePressure.jsm',
+    'ShieldStudySavant.jsm',
     'SiteDataManager.jsm',
     'SitePermissions.jsm',
     'ThemeVariableMap.jsm',


### PR DESCRIPTION
This PR:
* Adds the `shield.savant.enabled` and `shield.savant.loglevel` prefs in `firefox.js` to turn on/off the study code and study logging, respectively.
* Creates and registers the `ShieldStudySavant.jsm` module in `./browser/modules`.
* Initializes the `ShieldStudySavant.jsm` module from `nsBrowserGlue.js`.
* Sets up pref-controllable logging in `ShieldStudySavant.jsm` via the `shield.savant.loglevel` pref.
* Reads the current value of the `shield.savant.enabled` pref and watches it for changes.
  * If the pref is turned ON, it calls a stub `enableCollection` method
  * Conversely, if the pref is turned OFF, it calls a stub `disableCollection` method by way of the `endStudy` method

TODO: Add more functionality to the `ShieldStudySavant.init()` method
* Check for user eligibility (how to "endStudy"?)