### PR TITLE
Bug 1465685 - Add Password Manager and login form probes; r=MattN

### DIFF
--- a/browser/components/nsBrowserGlue.js
+++ b/browser/components/nsBrowserGlue.js
@@ -229,6 +229,7 @@ const listeners = {
     "RemoteLogins:insecureLoginFormPresent": ["LoginManagerParent"],
     // For Savant Shield study, bug 1465685. Study on desktop only.
     "LoginStats:LoginFillSuccessful": ["LoginManagerParent"],
+    "LoginStats:LoginEncountered": ["LoginManagerParent"],
     // PLEASE KEEP THIS LIST IN SYNC WITH THE MOBILE LISTENERS IN BrowserCLH.js
     "WCCR:registerProtocolHandler": ["Feeds"],
     "WCCR:registerContentHandler": ["Feeds"],

--- a/browser/components/nsBrowserGlue.js
+++ b/browser/components/nsBrowserGlue.js
@@ -227,6 +227,8 @@ const listeners = {
     "RemoteLogins:autoCompleteLogins": ["LoginManagerParent"],
     "RemoteLogins:removeLogin": ["LoginManagerParent"],
     "RemoteLogins:insecureLoginFormPresent": ["LoginManagerParent"],
+    // For Savant Shield study, bug 1465685. Study on desktop only.
+    "LoginStats:LoginFillSuccessful": ["LoginManagerParent"],
     // PLEASE KEEP THIS LIST IN SYNC WITH THE MOBILE LISTENERS IN BrowserCLH.js
     "WCCR:registerProtocolHandler": ["Feeds"],
     "WCCR:registerContentHandler": ["Feeds"],

--- a/browser/modules/SavantShieldStudy.jsm
+++ b/browser/modules/SavantShieldStudy.jsm
@@ -2,6 +2,8 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this file,
 * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/* eslint semi: error */
+
 "use strict";
 
 var EXPORTED_SYMBOLS = ["SavantShieldStudy"];

--- a/toolkit/components/passwordmgr/LoginManagerContent.jsm
+++ b/toolkit/components/passwordmgr/LoginManagerContent.jsm
@@ -438,8 +438,14 @@ var LoginManagerContent = {
   _fetchLoginsFromParentAndFillForm(form, window) {
     this._detectInsecureFormLikes(window);
 
+    const isPrivateWindow = PrivateBrowsingUtils.isContentWindowPrivate(window);
+
     let messageManager = messageManagerFromWindow(window);
-    messageManager.sendAsyncMessage("LoginStats:LoginEncountered");
+    messageManager.sendAsyncMessage("LoginStats:LoginEncountered",
+                                    {
+                                      isPrivateWindow,
+                                      isPwmgrEnabled: gEnabled,
+                                    });
 
     if (!gEnabled) {
       return;

--- a/toolkit/components/passwordmgr/LoginManagerParent.jsm
+++ b/toolkit/components/passwordmgr/LoginManagerParent.jsm
@@ -93,6 +93,13 @@ var LoginManagerParent = {
                           data.oldPasswordField,
                           msg.objects.openerTopWindow,
                           msg.target);
+
+        const flow_id = msg.target.ownerGlobal.gBrowser.getTabForBrowser(msg.target).linkedPanel;
+        Services.telemetry.recordEvent("savant", "login_form", "submit", null,
+                                      {
+                                        subcategory: "encounter",
+                                        flow_id,
+                                      });
         break;
       }
 
@@ -118,6 +125,18 @@ var LoginManagerParent = {
                                       {
                                         subcategory: "feature",
                                         flow_id,
+                                      });
+        break;
+      }
+
+      case "LoginStats:LoginEncountered": {
+        const canRecordSubmit = (!data.isPrivateWindow && data.isPwmgrEnabled).toString();
+        const flow_id = msg.target.ownerGlobal.gBrowser.getTabForBrowser(msg.target).linkedPanel;
+        Services.telemetry.recordEvent("savant", "login_form", "load", null,
+                                      {
+                                        subcategory: "encounter",
+                                        flow_id,
+                                        canRecordSubmit,
                                       });
         break;
       }

--- a/toolkit/components/passwordmgr/LoginManagerParent.jsm
+++ b/toolkit/components/passwordmgr/LoginManagerParent.jsm
@@ -111,6 +111,16 @@ var LoginManagerParent = {
         AutoCompletePopup.removeLogin(login);
         break;
       }
+
+      case "LoginStats:LoginFillSuccessful": {
+        const flow_id = msg.target.ownerGlobal.gBrowser.getTabForBrowser(msg.target).linkedPanel;
+        Services.telemetry.recordEvent("savant", "pwmgr_use", "use", null,
+                                      {
+                                        subcategory: "feature",
+                                        flow_id,
+                                      });
+        break;
+      }
     }
 
     return undefined;

--- a/toolkit/components/passwordmgr/nsLoginManagerPrompter.js
+++ b/toolkit/components/passwordmgr/nsLoginManagerPrompter.js
@@ -822,6 +822,14 @@ LoginManagerPrompter.prototype = {
     let histogram = Services.telemetry.getHistogramById(histogramName);
     histogram.add(PROMPT_DISPLAYED);
 
+    const promptType = type == "password-save" ? "save" : "update";
+    const flow_id = browser.ownerGlobal.gBrowser.getTabForBrowser(browser).linkedPanel;
+    Services.telemetry.recordEvent("savant", "pwmgr", "ask", promptType,
+                                  {
+                                    subcategory: "prompt",
+                                    flow_id,
+                                  });
+
     let chromeDoc = browser.ownerDocument;
 
     let currentNotification;
@@ -949,8 +957,20 @@ LoginManagerPrompter.prototype = {
       accessKey: this._getLocalizedString(initialMsgNames.buttonAccessKey),
       callback: () => {
         histogram.add(PROMPT_ADD_OR_UPDATE);
+        const flow_id = browser.ownerGlobal.gBrowser.getTabForBrowser(browser).linkedPanel;
         if (histogramName == "PWMGR_PROMPT_REMEMBER_ACTION") {
           Services.obs.notifyObservers(null, "LoginStats:NewSavedPassword");
+          Services.telemetry.recordEvent("savant", "pwmgr", "save", null,
+                                        {
+                                          subcategory: "prompt",
+                                          flow_id,
+                                        });
+        } else if (histogramName == "PWMGR_PROMPT_UPDATE_ACTION") {
+          Services.telemetry.recordEvent("savant", "pwmgr", "update", null,
+                                        {
+                                          subcategory: "prompt",
+                                          flow_id,
+                                        });
         }
         readDataFromUI();
         persistData();

--- a/toolkit/components/telemetry/Events.yaml
+++ b/toolkit/components/telemetry/Events.yaml
@@ -255,6 +255,22 @@ savant:
     extra_keys:
       subcategory: The broad event category for this probe. E.g. navigation
       flow_id: A tab identifier to associate events occuring in the same tab
+  login_form:
+    objects: ["load", "submit"]
+    release_channel_collection: opt-out
+    record_in_processes: ["main"]
+    description: >
+      A login form has been loaded or submitted. Login form submit events only
+      fire in non-private windows with Password Manager enabled.
+    bug_numbers: [1457226, 1465685]
+    notification_emails:
+      - "bdanforth@mozilla.com"
+      - "shong@mozilla.com"
+    expiry_version: "65"
+    extra_keys:
+      subcategory: The broad event category for this probe. E.g. navigation
+      flow_id: A tab identifier to associate events occuring in the same tab
+      canRecordSubmit: True if a login form loads in a non-private window with Password Manager enabled.
 
 # This category contains event entries used for Telemetry tests.
 # They will not be sent out with any pings.

--- a/toolkit/components/telemetry/Events.yaml
+++ b/toolkit/components/telemetry/Events.yaml
@@ -226,6 +226,35 @@ savant:
     expiry_version: "65"
     extra_keys:
       subcategory: The broad event category for this probe. E.g. navigation
+  pwmgr_use:
+    objects: ["use"]
+    release_channel_collection: opt-out
+    record_in_processes: ["main"]
+    description: >
+      Client uses saved login information from the Password Manager
+    bug_numbers: [1457226, 1465685]
+    notification_emails:
+      - "bdanforth@mozilla.com"
+      - "shong@mozilla.com"
+    expiry_version: "65"
+    extra_keys:
+      subcategory: The broad event category for this probe. E.g. navigation
+      flow_id: A tab identifier to associate events occuring in the same tab
+  pwmgr:
+    objects: ["ask", "save", "update"]
+    release_channel_collection: opt-out
+    record_in_processes: ["main"]
+    description: >
+      Password Manager asks the user to save or update login information.
+      For ask prompts, the value field indicate a save versus update ask.
+    bug_numbers: [1457226, 1465685]
+    notification_emails:
+      - "bdanforth@mozilla.com"
+      - "shong@mozilla.com"
+    expiry_version: "65"
+    extra_keys:
+      subcategory: The broad event category for this probe. E.g. navigation
+      flow_id: A tab identifier to associate events occuring in the same tab
 
 # This category contains event entries used for Telemetry tests.
 # They will not be sent out with any pings.


### PR DESCRIPTION
Corresponding [Bugzilla bug 1465685](https://bugzilla.mozilla.org/show_bug.cgi?id=1465685)

Fixes #20. Fixes #24.

TODO
- [x] Create issue detailing implementation and any limitations or additional details
- [x] Update TESTPLAN.md (Issue #5 )
- [x] Get rid of promise/getFlowID method, set flowID to tabID for all probes. Add flow_id to pw_manager_use probe. Update Events.yaml accordingly.
- [x] Import commits into Hg and run this PR on the Try server with study pref ON and OFF (`./mach try -b o -p win64,linux64,macosx64 -u mochitests,xpcshell -t none`). Post links in this PR. Resolve issues as required.
- [x] Push to Review Board, push to Try again via RB GUI
- [x] obtain r+ from Peer (MattN) and QA (pdehaan)
- [x] Land patch in Nightly