### PR TITLE
Bug 1465707 - Add addon probes for Savant Shield study; r=rhelmer

### DIFF
--- a/toolkit/components/telemetry/Events.yaml
+++ b/toolkit/components/telemetry/Events.yaml
@@ -133,6 +133,21 @@ savant:
     expiry_version: "65"
     extra_keys:
       subcategory: The broad event category for this probe. E.g. navigation
+  addon:
+    objects: ["install_start", "install_finish", "remove_start", "remove_finish",
+              "enable", "disable" ]
+    release_channel_collection: opt-out
+    record_in_processes: ["main"]
+    description: >
+      This is recorded any time an addon event as listed in the objects field fires.
+      The value field records the addon ID for the event.
+    bug_numbers: [1457226, 1465707]
+    notification_emails:
+      - "bdanforth@mozilla.com"
+      - "shong@mozilla.com"
+    expiry_version: "65"
+    extra_keys:
+      subcategory: The broad event category for this probe. E.g. navigation
 
 # This category contains event entries used for Telemetry tests.
 # They will not be sent out with any pings.


### PR DESCRIPTION
Fixes #25 .

TODO
- [x] Create issue detailing implementation and any limitations or additional details
- [x] Update TESTPLAN.md (Issue #5 )
- [x] TODO remove flow_id/getFlowID, add addonID as value, update events.yaml description, redo functional tests
- [x] Import commits into Hg and run this PR on the Try server with study pref ON and OFF (`./mach try -b o -p win64,linux64,macosx64 -u mochitests,xpcshell -t none`). Post links in this PR. Resolve issues as required.
- [x] Push to Review Board, push to Try again via RB GUI
- [x] obtain r+ from Peer (rhelmer) and QA (pdehaan)
- [x] Land patch in Nightly

When the study preference (shield.savant.enabled) is set to true, this will record:
* When an addon begins an install
* When an addon finishes an install
* When an addon is enabled
* When an addon is disabled
* When an addon begins an uninstall
* When an addon finishes an uninstall

Each event is given a flow_id, which is a hash of the addon ID and the telemetry client ID. This will associate different events with the same add-on regardless of when they may occur.