### PR TITLE
Bug 1465703 - Add bookmark and follow_bookmark probes for Savant Shie…

### DIFF
--- a/browser/components/nsBrowserGlue.js
+++ b/browser/components/nsBrowserGlue.js
@@ -1060,8 +1060,6 @@ BrowserGlue.prototype = {
 
     // Set the default favicon size for UI views that use the page-icon protocol.
     PlacesUtils.favicons.setDefaultIconURIPreferredSize(16 * aWindow.devicePixelRatio);
-
-    SavantShieldStudy.init();
   },
 
   _sendMediaTelemetry() {
@@ -1271,6 +1269,10 @@ BrowserGlue.prototype = {
 
     Services.tm.idleDispatchToMainThread(() => {
       Blocklist.loadBlocklistAsync();
+    });
+
+    Services.tm.idleDispatchToMainThread(() => {
+      SavantShieldStudy.init();
     });
   },
 

--- a/toolkit/components/telemetry/Events.yaml
+++ b/toolkit/components/telemetry/Events.yaml
@@ -148,6 +148,32 @@ savant:
     expiry_version: "65"
     extra_keys:
       subcategory: The broad event category for this probe. E.g. navigation
+  bookmark:
+    objects: ["save", "remove"]
+    release_channel_collection: opt-out
+    record_in_processes: ["main"]
+    description: >
+      This is recorded any time a bookmark is saved or removed.
+    bug_numbers: [1457226, 1465703]
+    notification_emails:
+      - "bdanforth@mozilla.com"
+      - "shong@mozilla.com"
+    expiry_version: "65"
+    extra_keys:
+      subcategory: The broad event category for this probe. E.g. navigation
+  follow_bookmark:
+    objects: ["open"]
+    release_channel_collection: opt-out
+    record_in_processes: ["main"]
+    description: >
+      This is recorded any time a bookmark is visited.
+    bug_numbers: [1457226, 1465703]
+    notification_emails:
+      - "bdanforth@mozilla.com"
+      - "shong@mozilla.com"
+    expiry_version: "65"
+    extra_keys:
+      subcategory: The broad event category for this probe. E.g. navigation
 
 # This category contains event entries used for Telemetry tests.
 # They will not be sent out with any pings.


### PR DESCRIPTION
…ld study; r=mak, adw

Fixes #27 

TODO
- [x] Create issue detailing implementation and any limitations or additional details
- [x] Update TESTPLAN.md (Issue #5 )
- [x] Import commits into Hg and run this PR on the Try server with study pref ON and OFF (`./mach try -b o -p win64,linux64,macosx64 -u mochitests,xpcshell -t none`). Post links in this PR. Resolve issues as required.
- [x] Push to Review Board, push to Try again via RB GUI
- [x] obtain r+ from Peer (mak OR adw) and QA (pdehaan)
- [x] Land patch in Nightly

These probes will register and record (for the duration of the study only):
* When a bookmark is added.
* When a bookmark is removed.
* When a bookmark is visited.

Note for bookmark added: Using the 'onItemAdded' nsINavBookmarkObserver will not distinguish bulk adds (as from creation of default bookmarks for a new user, bookmark migration from another browser, Sync, ...) from one-off adds by the user through the UI. This observer will be used for simplicity, since there are many locations in the UI where a user can add a bookmark. More fine grained probes can be implemented later if desired.

Note for bookmark visited: This will also fire for the case when the user visits a page directly that happens to be bookmarked. The user doesn't have to "click" on a bookmark.