### PR TITLE
Bug 1465694 - Add tab event telemetry for Savant Shield study; r=dao

### DIFF
--- a/browser/base/content/tabbrowser.js
+++ b/browser/base/content/tabbrowser.js
@@ -1040,6 +1040,7 @@ window._gBrowser = {
         }
       });
       newTab.dispatchEvent(event);
+      Services.telemetry.recordEvent("savant", "tab", "select", null, { subcategory: "frame" });
 
       this._tabAttrModified(oldTab, ["selected"]);
       this._tabAttrModified(newTab, ["selected"]);
@@ -2460,6 +2461,7 @@ window._gBrowser = {
     var detail = aEventDetail || {};
     var evt = new CustomEvent("TabOpen", { bubbles: true, detail });
     t.dispatchEvent(evt);
+    Services.telemetry.recordEvent("savant", "tab", "open", null, { subcategory: "frame" });
 
     if (!usingPreloadedContent && aOriginPrincipal && aURI) {
       let { URI_INHERITS_SECURITY_CONTEXT } = Ci.nsIProtocolHandler;
@@ -2847,6 +2849,7 @@ window._gBrowser = {
     // inspect the tab that's about to close.
     var evt = new CustomEvent("TabClose", { bubbles: true, detail: { adoptedBy: aAdoptedByTab } });
     aTab.dispatchEvent(evt);
+    Services.telemetry.recordEvent("savant", "tab", "close", null, { subcategory: "frame" });
 
     if (aTab.linkedPanel) {
       if (!aAdoptedByTab && !gMultiProcessBrowser) {

--- a/toolkit/components/telemetry/Events.yaml
+++ b/toolkit/components/telemetry/Events.yaml
@@ -271,6 +271,19 @@ savant:
       subcategory: The broad event category for this probe. E.g. navigation
       flow_id: A tab identifier to associate events occuring in the same tab
       canRecordSubmit: True if a login form loads in a non-private window with Password Manager enabled.
+  tab:
+    objects: ["open", "close", "select"]
+    release_channel_collection: opt-out
+    record_in_processes: ["main"]
+    description: >
+      This is recorded any time a tab is opened, closed or selected.
+    bug_numbers: [1457226, 1465694]
+    notification_emails:
+      - "bdanforth@mozilla.com"
+      - "shong@mozilla.com"
+    expiry_version: "65"
+    extra_keys:
+      subcategory: The broad event category for this probe. E.g. navigation
 
 # This category contains event entries used for Telemetry tests.
 # They will not be sent out with any pings.


### PR DESCRIPTION
Fixes #29 .

TODO
- [x] Create issue detailing implementation and any limitations or additional details
- [x] Update TESTPLAN.md (Issue #5 )
- [x] Import commits into Hg and run this PR on the Try server with study pref ON and OFF (`./mach try -b o -p win64,linux64,macosx64 -u mochitests,xpcshell -t none`). Post links in this PR. Resolve issues as required.
- [x] Push to Review Board, push to Try again via RB GUI
- [x] obtain r+ from Peer (dao) and QA (pdehaan)
- [x] Land patch in Nightly

These probes will register and record (for the duration of the study only):
* When a tab opens.
* When a tab closes.
* When a tab is selected.
* When a tab moves.