### PR TITLE
Bug 1465704 - Add follow_urlbar_link event telemetry for Savant Shiel…

### DIFF
--- a/browser/modules/BrowserUsageTelemetry.jsm
+++ b/browser/modules/BrowserUsageTelemetry.jsm
@@ -306,6 +306,10 @@ let urlbarListener = {
       Services.telemetry
               .getKeyedHistogramById("FX_URLBAR_SELECTED_RESULT_INDEX_BY_TYPE")
               .add(actionType, idx);
+      if (actionType === "bookmark" || actionType === "history") {
+        Services.telemetry.recordEvent("savant", "follow_urlbar_link", actionType, null,
+                                      { subcategory: "navigation" });
+      }
     } else {
       Cu.reportError("Unknown FX_URLBAR_SELECTED_RESULT_TYPE type: " +
                      actionType);

--- a/toolkit/components/telemetry/Events.yaml
+++ b/toolkit/components/telemetry/Events.yaml
@@ -174,6 +174,19 @@ savant:
     expiry_version: "65"
     extra_keys:
       subcategory: The broad event category for this probe. E.g. navigation
+  follow_urlbar_link:
+    objects: ["bookmark", "history"]
+    release_channel_collection: opt-out
+    record_in_processes: ["main"]
+    description: >
+      This is recorded when the user selects a urlbar bookmark or history result.
+    bug_numbers: [1457226, 1465704]
+    notification_emails:
+      - "bdanforth@mozilla.com"
+      - "shong@mozilla.com"
+    expiry_version: "65"
+    extra_keys:
+      subcategory: The broad event category for this probe. E.g. navigation
 
 # This category contains event entries used for Telemetry tests.
 # They will not be sent out with any pings.


### PR DESCRIPTION
…d study; r=mak, adw

Fixes #31 .

TODO
- [x] Create issue detailing implementation and any limitations or additional details
- [x] Update TESTPLAN.md (Issue #5 )
- [x] Import commits into Hg and run this PR on the Try server with study pref ON and OFF (`./mach try -b o -p win64,linux64,macosx64 -u mochitests,xpcshell -t none`). Post links in this PR. Resolve issues as required.
- [x] Push to Review Board, push to Try again via RB GUI
- [x] obtain r+ from Peer (mak or adw) and QA (pdehaan)
- [x] Land patch in Nightly

These probes will register and record (for the duration of the study only):
* When the user clicks on a history link displayed by the urlbar
* When the user clicks on a bookmark link displayed by the urlbar

It should be noted that the same site can be multiple result types at the same time, so there will be times when a bookmark and/or history selection is captured as a result type other than bookmark or history (e.g. 'switchtab', 'autofill' or 'visiturl').