### PR TITLE
Bug 1465698 - Add readermode event probes for Savant Shield study; r=…

### DIFF
--- a/toolkit/components/reader/ReaderMode.jsm
+++ b/toolkit/components/reader/ReaderMode.jsm
@@ -96,6 +96,9 @@ var ReaderMode = {
    * if not, append the about:reader page in the history instead.
    */
   enterReaderMode(docShell, win) {
+    Services.telemetry.recordEvent("savant", "readermode", "on", null,
+                                  { subcategory: "feature" });
+
     let url = win.document.location.href;
     let readerURL = "about:reader?url=" + encodeURIComponent(url);
     let webNav = docShell.QueryInterface(Ci.nsIWebNavigation);
@@ -117,6 +120,8 @@ var ReaderMode = {
    * if not, append the original page in the history instead.
    */
   leaveReaderMode(docShell, win) {
+    Services.telemetry.recordEvent("savant", "readermode", "off", null,
+                                  { subcategory: "feature" });
     let url = win.document.location.href;
     let originalURL = this.getOriginalUrl(url);
     let webNav = docShell.QueryInterface(Ci.nsIWebNavigation);

--- a/toolkit/components/telemetry/Events.yaml
+++ b/toolkit/components/telemetry/Events.yaml
@@ -120,6 +120,19 @@ savant:
     expiry_version: "65"
     extra_keys:
       subcategory: The broad event category for this probe. E.g. navigation
+  readermode:
+    objects: ["on", "off"]
+    release_channel_collection: opt-out
+    record_in_processes: ["content"]
+    description: >
+      This is recorded any time Reader Mode is turned on or off.
+    bug_numbers: [1457226, 1465698]
+    notification_emails:
+      - "bdanforth@mozilla.com"
+      - "shong@mozilla.com"
+    expiry_version: "65"
+    extra_keys:
+      subcategory: The broad event category for this probe. E.g. navigation
 
 # This category contains event entries used for Telemetry tests.
 # They will not be sent out with any pings.


### PR DESCRIPTION
…jaws

Fixes #33 .

TODO
- [x] Create issue detailing implementation and any limitations or additional details
- [x] Update TESTPLAN.md (Issue #5 )
- [x] Import commits into Hg and run this PR on the Try server with study pref ON and OFF (`./mach try -b o -p win64,linux64,macosx64 -u mochitests,xpcshell -t none`). Post links in this PR. Resolve issues as required.
- [x] Push to Review Board, push to Try again via RB GUI
- [x] obtain r+ from Peer (mak or adw) and QA (pdehaan)
- [x] Land patch in Nightly

These probes will register and record (for the duration of the study only):
* When the user turns on Reader Mode.
* When the user turns off Reader Mode.

Note: The events are recorded in the content process.