### PR TITLE
Bug 1465697 - Add menu open probes for Savant Shield study; r=jaws

### DIFF
--- a/browser/modules/SavantShieldStudy.jsm
+++ b/browser/modules/SavantShieldStudy.jsm
@@ -40,9 +40,10 @@ class SavantShieldStudyClass {
   }
 
   init() {
-    this.TelemetryEvents = new TelemetryEvents(this.STUDY_TELEMETRY_CATEGORY);
-    this.AddonListener = new AddonListener(this.STUDY_TELEMETRY_CATEGORY);
-    this.BookmarkObserver = new BookmarkObserver(this.STUDY_TELEMETRY_CATEGORY);
+    this.telemetryEvents = new TelemetryEvents(this.STUDY_TELEMETRY_CATEGORY);
+    this.addonListener = new AddonListener(this.STUDY_TELEMETRY_CATEGORY);
+    this.bookmarkObserver = new BookmarkObserver(this.STUDY_TELEMETRY_CATEGORY);
+    this.menuListener = new MenuListener(this.STUDY_TELEMETRY_CATEGORY);
 
     // check the pref in case Normandy flipped it on before we could add the pref listener
     this.shouldCollect = Services.prefs.getBoolPref(this.STUDY_PREF);
@@ -67,7 +68,7 @@ class SavantShieldStudyClass {
 
   startupStudy() {
     // enable before any possible calls to endStudy, since it sends an 'end_study' event
-    this.TelemetryEvents.enableCollection();
+    this.telemetryEvents.enableCollection();
 
     if (!this.isEligible()) {
       this.endStudy("ineligible");
@@ -81,8 +82,9 @@ class SavantShieldStudyClass {
       this.endStudy("expired");
     }
 
-    this.AddonListener.init();
-    this.BookmarkObserver.init();
+    this.addonListener.init();
+    this.bookmarkObserver.init();
+    this.menuListener.init();
   }
 
   isEligible() {
@@ -142,7 +144,7 @@ class SavantShieldStudyClass {
     const isStudyEnding = true;
     Services.telemetry.recordEvent(this.STUDY_TELEMETRY_CATEGORY, "end_study", reason, null,
                                   { subcategory: "shield" });
-    this.TelemetryEvents.disableCollection();
+    this.telemetryEvents.disableCollection();
     this.uninit(isStudyEnding);
     // These prefs needs to persist between restarts, so only reset on endStudy
     Services.prefs.clearUserPref(this.STUDY_PREF);
@@ -159,8 +161,9 @@ class SavantShieldStudyClass {
       return;
     }
 
-    this.AddonListener.uninit();
-    this.BookmarkObserver.uninit();
+    this.addonListener.uninit();
+    this.bookmarkObserver.uninit();
+    this.menuListener.uninit();
 
     Services.prefs.removeObserver(this.ALWAYS_PRIVATE_BROWSING_PREF, this);
     Services.prefs.removeObserver(this.STUDY_PREF, this);
@@ -315,6 +318,203 @@ class BookmarkObserver {
 
   uninit() {
     this.removeObservers();
+  }
+}
+
+class MenuListener {
+  constructor(studyCategory) {
+    this.STUDY_TELEMETRY_CATEGORY = studyCategory;
+    this.NAVIGATOR_TOOLBOX_ID = "navigator-toolbox";
+    this.OVERFLOW_PANEL_ID = "widget-overflow";
+    this.LIBRARY_PANELVIEW_ID = "appMenu-libraryView";
+    this.HAMBURGER_PANEL_ID = "appMenu-popup";
+    this.DOTDOTDOT_PANEL_ID = "pageActionPanel";
+    this.windowWatcher = new WindowWatcher();
+  }
+
+  init() {
+    this.windowWatcher.init(this.loadIntoWindow.bind(this),
+    this.unloadFromWindow.bind(this),
+    this.onWindowError.bind(this));
+  }
+
+ loadIntoWindow(win) {
+    this.addListeners(win);
+  }
+
+  unloadFromWindow(win) {
+    this.removeListeners(win);
+  }
+
+  onWindowError(msg) {
+    log.error(msg);
+  }
+
+  addListeners(win) {
+    const doc = win.document;
+    const navToolbox = doc.getElementById(this.NAVIGATOR_TOOLBOX_ID);
+    const overflowPanel = doc.getElementById(this.OVERFLOW_PANEL_ID);
+    const hamburgerPanel = doc.getElementById(this.HAMBURGER_PANEL_ID);
+    const dotdotdotPanel = doc.getElementById(this.DOTDOTDOT_PANEL_ID);
+
+    /*
+    * the library menu "ViewShowing" event bubbles up on the navToolbox in its
+    * default location. A separate listener is needed if it is moved to the
+    * overflow panel via Hamburger > Customize
+    */
+    navToolbox.addEventListener("ViewShowing", this);
+    overflowPanel.addEventListener("ViewShowing", this);
+    hamburgerPanel.addEventListener("popupshown", this);
+    dotdotdotPanel.addEventListener("popupshown", this);
+  }
+
+  handleEvent(evt) {
+    switch (evt.type) {
+      case "ViewShowing":
+        if (evt.target.id === this.LIBRARY_PANELVIEW_ID) {
+          log.debug("Library panel opened.");
+          this.recordEvent("library_menu");
+        }
+        break;
+      case "popupshown":
+        switch (evt.target.id) {
+          case this.HAMBURGER_PANEL_ID:
+            log.debug("Hamburger panel opened.");
+            this.recordEvent("hamburger_menu");
+            break;
+          case this.DOTDOTDOT_PANEL_ID:
+            log.debug("Dotdotdot panel opened.");
+            this.recordEvent("dotdotdot_menu");
+            break;
+          default:
+            break;
+        }
+      break;
+    }
+  }
+
+  recordEvent(method) {
+    Services.telemetry.recordEvent(this.STUDY_TELEMETRY_CATEGORY, method, "open", null,
+                                  { subcategory: "menu" });
+  }
+
+  removeListeners(win) {
+    const doc = win.document;
+    const navToolbox = doc.getElementById(this.NAVIGATOR_TOOLBOX_ID);
+    const overflowPanel = doc.getElementById(this.OVERFLOW_PANEL_ID);
+    const hamburgerPanel = doc.getElementById(this.HAMBURGER_PANEL_ID);
+    const dotdotdotPanel = doc.getElementById(this.DOTDOTDOT_PANEL_ID);
+
+    try {
+      navToolbox.removeEventListener("ViewShowing", this);
+      overflowPanel.removeEventListener("ViewShowing", this);
+      hamburgerPanel.removeEventListener("popupshown", this);
+      dotdotdotPanel.removeEventListener("popupshown", this);
+    } catch (err) {
+      // Firefox is shutting down; elements have already been removed.
+    }
+  }
+
+  uninit() {
+    this.windowWatcher.uninit();
+  }
+}
+
+/*
+* The WindowWatcher is used to add/remove listeners from MenuListener
+* to/from all windows.
+*/
+class WindowWatcher {
+  constructor() {
+    this._isActive = false;
+    this._loadCallback = null;
+    this._unloadCallback = null;
+    this._errorCallback = null;
+  }
+
+  // It is expected that loadCallback, unloadCallback, and errorCallback are bound
+  // to a `this` value.
+  init(loadCallback, unloadCallback, errorCallback) {
+    if (this._isActive) {
+      errorCallback("Called init, but WindowWatcher was already running");
+      return;
+    }
+
+    this._isActive = true;
+    this._loadCallback = loadCallback;
+    this._unloadCallback = unloadCallback;
+    this._errorCallback = errorCallback;
+
+    // Add loadCallback to existing windows
+    const windows = Services.wm.getEnumerator("navigator:browser");
+    while (windows.hasMoreElements()) {
+      const win = windows.getNext();
+      try {
+        this._loadCallback(win);
+      } catch (ex) {
+        this._errorCallback(`WindowWatcher code loading callback failed: ${ ex }`);
+      }
+    }
+
+    // Add loadCallback to future windows
+    // This will call the observe method on WindowWatcher
+    Services.ww.registerNotification(this);
+  }
+
+  uninit() {
+    if (!this._isActive) {
+      this._errorCallback("Called uninit, but WindowWatcher was already uninited");
+      return;
+    }
+
+    const windows = Services.wm.getEnumerator("navigator:browser");
+    while (windows.hasMoreElements()) {
+      const win = windows.getNext();
+      try {
+        this._unloadCallback(win);
+      } catch (ex) {
+        this._errorCallback(`WindowWatcher code unloading callback failed: ${ ex }`);
+      }
+    }
+
+    Services.ww.unregisterNotification(this);
+
+    this._loadCallback = null;
+    this._unloadCallback = null;
+    this._errorCallback = null;
+    this._isActive = false;
+  }
+
+  observe(win, topic) {
+    switch (topic) {
+      case "domwindowopened":
+        this._onWindowOpened(win);
+        break;
+      case "domwindowclosed":
+        this._onWindowClosed(win);
+        break;
+      default:
+        break;
+    }
+  }
+
+  _onWindowOpened(win) {
+    win.addEventListener("load", this, { once: true });
+  }
+
+  // only one event type expected: "load"
+  handleEvent(evt) {
+    const win = evt.target.ownerGlobal;
+
+    // make sure we only add window listeners to a DOMWindow (browser.xul)
+    const winType = win.document.documentElement.getAttribute("windowtype");
+    if (winType === "navigator:browser") {
+      this._loadCallback(win);
+    }
+  }
+
+  _onWindowClosed(win) {
+    this._unloadCallback(win);
   }
 }
 

--- a/toolkit/components/telemetry/Events.yaml
+++ b/toolkit/components/telemetry/Events.yaml
@@ -187,6 +187,45 @@ savant:
     expiry_version: "65"
     extra_keys:
       subcategory: The broad event category for this probe. E.g. navigation
+  library_menu:
+    objects: ["open"]
+    release_channel_collection: opt-out
+    record_in_processes: ["main"]
+    description: >
+      This is recorded any time the library menu is opened.
+    bug_numbers: [1457226, 1465697]
+    notification_emails:
+      - "bdanforth@mozilla.com"
+      - "shong@mozilla.com"
+    expiry_version: "65"
+    extra_keys:
+      subcategory: The broad event category for this probe. E.g. navigation
+  hamburger_menu:
+    objects: ["open"]
+    release_channel_collection: opt-out
+    record_in_processes: ["main"]
+    description: >
+      This is recorded any time the hamburger menu is opened.
+    bug_numbers: [1457226, 1465697]
+    notification_emails:
+      - "bdanforth@mozilla.com"
+      - "shong@mozilla.com"
+    expiry_version: "65"
+    extra_keys:
+      subcategory: The broad event category for this probe. E.g. navigation
+  dotdotdot_menu:
+    objects: ["open"]
+    release_channel_collection: opt-out
+    record_in_processes: ["main"]
+    description: >
+      This is recorded any time the dotdotdot (aka pageAction) menu is opened.
+    bug_numbers: [1457226, 1465697]
+    notification_emails:
+      - "bdanforth@mozilla.com"
+      - "shong@mozilla.com"
+    expiry_version: "65"
+    extra_keys:
+      subcategory: The broad event category for this probe. E.g. navigation
 
 # This category contains event entries used for Telemetry tests.
 # They will not be sent out with any pings.


### PR DESCRIPTION
Fixes #35 

WIP:
* Is there an easier way to add/remove listeners for windows than to use the WindowWatcher class I cobbled together from the Tracking Protection Messaging add-on study?

TODO
- [x] Create issue detailing implementation and any limitations or additional details
- [x] Update TESTPLAN.md (Issue #5 )
- [x] Import commits into Hg and run this PR on the Try server with study pref ON and OFF (`./mach try -b do -p win64,linux64,macosx64 -u mochitests,xpcshell -t none`). Post links in this PR. Resolve issues as required.
- [x] Push to Review Board, push to Try again via RB GUI
- [x] obtain r+ from Peer (mak or adw) and QA (pdehaan)
- [x] Land patch in Nightly

These probes will register and record (for the duration of the study only):
* When the library menu opens.
* When the hamburger menu opens.
* When the dotdotdot menu opens.

These will be captured in existing and new DOMWindows.